### PR TITLE
Implement cookie consent banner with Google Consent Mode

### DIFF
--- a/_includes/analytics/google.html
+++ b/_includes/analytics/google.html
@@ -1,0 +1,16 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script defer src="https://www.googletagmanager.com/gtag/js?id={{ site.analytics.google.id }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+
+  gtag('consent', 'default', {
+    ad_storage: 'denied',
+    analytics_storage: 'denied',
+    ad_user_data: 'denied',
+    ad_personalization: 'denied'
+  });
+
+  gtag('js', new Date());
+  gtag('config', '{{ site.analytics.google.id }}');
+</script>

--- a/_includes/cookie-banner.html
+++ b/_includes/cookie-banner.html
@@ -1,0 +1,27 @@
+<div id="cookie-banner" class="cookie-banner d-none">
+  <div class="cookie-banner-body">
+    <p>Questo sito utilizza cookie per migliorare l'esperienza di navigazione.</p>
+    <div class="cookie-buttons">
+      <button id="cookie-accept" class="btn btn-primary">Accetta tutto</button>
+      <button id="cookie-reject" class="btn btn-secondary">Rifiuta tutto</button>
+      <button id="cookie-customize" class="btn btn-outline-primary">Personalizza</button>
+    </div>
+  </div>
+</div>
+
+<div id="cookie-modal" class="cookie-modal d-none">
+  <div class="cookie-modal-body">
+    <h5>Preferenze cookie</h5>
+    <form id="cookie-form">
+      <div class="form-check">
+        <input class="form-check-input" type="checkbox" id="consent-analytics">
+        <label class="form-check-label" for="consent-analytics">Cookie analitici</label>
+      </div>
+      <div class="form-check">
+        <input class="form-check-input" type="checkbox" id="consent-marketing">
+        <label class="form-check-label" for="consent-marketing">Cookie marketing</label>
+      </div>
+      <button type="button" id="cookie-save" class="btn btn-primary mt-2">Salva preferenze</button>
+    </form>
+  </div>
+</div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,53 @@
+<!-- The Footer -->
+
+<footer
+  aria-label="Site Info"
+  class="
+    d-flex flex-column justify-content-center text-muted
+    flex-lg-row justify-content-lg-between align-items-lg-center pb-lg-3
+  "
+>
+  <p>
+    {{- '©' }}
+    <time>{{ 'now' | date: '%Y' }}</time>
+
+    {% if site.social.links %}
+      <a href="{{ site.social.links[0] }}">{{ site.social.name }}</a>.
+    {% else %}
+      <em class="fst-normal">{{ site.social.name }}</em>.
+    {% endif %}
+
+    {% if site.data.locales[include.lang].copyright.brief %}
+      <span
+        data-bs-toggle="tooltip"
+        data-bs-placement="top"
+        title="{{ site.data.locales[include.lang].copyright.verbose }}"
+      >
+        {{- site.data.locales[include.lang].copyright.brief -}}
+      </span>
+    {% endif %}
+  </p>
+
+  <p>
+    <a href="#" id="cookie-settings-link">Preferenze cookie</a>
+  </p>
+
+  <p>
+    {%- capture _platform -%}
+      <a href="https://jekyllrb.com" target="_blank" rel="noopener">Jekyll</a>
+    {%- endcapture -%}
+
+    {%- capture _theme -%}
+      <a
+        data-bs-toggle="tooltip"
+        data-bs-placement="top"
+        title="v{{ theme.version }}"
+        href="https://github.com/cotes2020/jekyll-theme-chirpy"
+        target="_blank"
+        rel="noopener"
+      >Chirpy</a>
+    {%- endcapture -%}
+
+    {{ site.data.locales[include.lang].meta | replace: ':PLATFORM', _platform | replace: ':THEME', _theme }}
+  </p>
+</footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,129 @@
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f7f7f7">
+  <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1b1b1e">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta
+    name="viewport"
+    content="width=device-width, user-scalable=no initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
+  >
+
+  {%- capture seo_tags -%}
+    {% seo title=false %}
+  {%- endcapture -%}
+
+  <!-- Setup Open Graph image -->
+
+  {% if page.image %}
+    {% assign src = page.image.path | default: page.image %}
+
+    {% unless src contains '://' %}
+      {%- capture img_url -%}
+        {% include media-url.html src=src subpath=page.media_subpath absolute=true %}
+      {%- endcapture -%}
+
+      {%- capture old_url -%}{{ src | absolute_url }}{%- endcapture -%}
+      {%- capture new_url -%}{{ img_url }}{%- endcapture -%}
+
+      {% assign seo_tags = seo_tags | replace: old_url, new_url %}
+    {% endunless %}
+
+  {% elsif site.social_preview_image %}
+    {%- capture img_url -%}
+      {% include media-url.html src=site.social_preview_image absolute=true %}
+    {%- endcapture -%}
+
+    {%- capture og_image -%}
+      <meta property="og:image" content="{{ img_url }}" />
+    {%- endcapture -%}
+
+    {%- capture twitter_image -%}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta property="twitter:image" content="{{ img_url }}" />
+    {%- endcapture -%}
+
+    {% assign old_meta_clip = '<meta name="twitter:card" content="summary" />' %}
+    {% assign new_meta_clip = og_image | append: twitter_image %}
+    {% assign seo_tags = seo_tags | replace: old_meta_clip, new_meta_clip %}
+  {% endif %}
+
+  {{ seo_tags }}
+
+  <title>
+    {%- unless page.layout == 'home' -%}
+      {{ page.title | append: ' | ' }}
+    {%- endunless -%}
+    {{ site.title }}
+  </title>
+
+  {% include_cached favicons.html %}
+
+  <!-- Resource Hints -->
+  {% unless site.assets.self_host.enabled %}
+    {% for hint in site.data.origin.cors.resource_hints %}
+      {% for link in hint.links %}
+        <link rel="{{ link.rel }}" href="{{ hint.url }}" {{ link.opts | join: ' ' }}>
+      {% endfor %}
+    {% endfor %}
+  {% endunless %}
+
+  <!-- Bootstrap -->
+  {% unless jekyll.environment == 'production' %}
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css">
+  {% endunless %}
+
+  <!-- Theme style -->
+  <link rel="stylesheet" href="{{ '/assets/css/:THEME.css' | replace: ':THEME', site.theme | relative_url }}">
+
+  <!-- Web Font -->
+  <link rel="stylesheet" href="{{ site.data.origin[type].webfonts | relative_url }}">
+
+  <!-- Font Awesome Icons -->
+  <link rel="stylesheet" href="{{ site.data.origin[type].fontawesome.css | relative_url }}">
+
+  <!-- 3rd-party Dependencies -->
+
+  {% if site.toc and page.toc %}
+    <link rel="stylesheet" href="{{ site.data.origin[type].toc.css | relative_url }}">
+  {% endif %}
+
+  {% if page.layout == 'post' or page.layout == 'page' or page.layout == 'home' %}
+    <link rel="stylesheet" href="{{ site.data.origin[type]['lazy-polyfill'].css | relative_url }}">
+  {% endif %}
+
+  {% if page.layout == 'page' or page.layout == 'post' %}
+    <!-- Image Popup -->
+    <link rel="stylesheet" href="{{ site.data.origin[type].glightbox.css | relative_url }}">
+  {% endif %}
+
+  <!-- Cookie banner style -->
+  <link rel="stylesheet" href="{{ '/assets/css/cookie-consent.css' | relative_url }}">
+
+  <!-- Scripts -->
+
+  <script src="{{ '/assets/js/dist/theme.min.js' | relative_url }}"></script>
+
+  {% include js-selector.html lang=lang %}
+
+  {% if jekyll.environment == 'production' %}
+    <!-- PWA -->
+    {% if site.pwa.enabled %}
+      <script
+        defer
+        src="{{ '/app.min.js' | relative_url }}?baseurl={{ site.baseurl | default: '' }}&register={{ site.pwa.cache.enabled }}"
+      ></script>
+    {% endif %}
+
+    <!-- Web Analytics -->
+    {% for analytics in site.analytics %}
+      {% capture str %}{{ analytics }}{% endcapture %}
+      {% assign platform = str | split: '{' | first %}
+      {% if site.analytics[platform].id and site.analytics[platform].id != empty %}
+        {% include analytics/{{ platform }}.html %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+
+  {% include metadata-hook.html %}
+</head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,89 @@
+---
+layout: compress
+---
+
+<!doctype html>
+
+{% include origin-type.html %}
+
+{% include lang.html %}
+
+{% if site.theme_mode %}
+  {% capture prefer_mode %}data-mode="{{ site.theme_mode }}"{% endcapture %}
+{% endif %}
+
+<!-- `site.alt_lang` can specify a language different from the UI -->
+<html lang="{{ page.lang | default: site.alt_lang | default: site.lang }}" {{ prefer_mode }}>
+  {% include head.html %}
+
+  <body>
+    {% include sidebar.html lang=lang %}
+
+    <div id="main-wrapper" class="d-flex justify-content-center">
+      <div class="container d-flex flex-column px-xxl-5">
+        {% include topbar.html lang=lang %}
+
+        <div class="row flex-grow-1">
+          <main aria-label="Main Content" class="col-12 col-lg-11 col-xl-9 px-md-4">
+            {% if layout.refactor or layout.layout == 'default' %}
+              {% include refactor-content.html content=content lang=lang %}
+            {% else %}
+              {{ content }}
+            {% endif %}
+          </main>
+
+          <!-- panel -->
+          <aside aria-label="Panel" id="panel-wrapper" class="col-xl-3 ps-2 text-muted">
+            <div class="access">
+              {% include_cached update-list.html lang=lang %}
+              {% include_cached trending-tags.html lang=lang %}
+            </div>
+
+            {% for _include in layout.panel_includes %}
+              {% assign _include_path = _include | append: '.html' %}
+              {% include {{ _include_path }} lang=lang %}
+            {% endfor %}
+          </aside>
+        </div>
+
+        <div class="row">
+          <!-- tail -->
+          <div id="tail-wrapper" class="col-12 col-lg-11 col-xl-9 px-md-4">
+            {% for _include in layout.tail_includes %}
+              {% assign _include_path = _include | append: '.html' %}
+              {% include {{ _include_path }} lang=lang %}
+            {% endfor %}
+
+            {% include_cached footer.html lang=lang %}
+          </div>
+        </div>
+
+        {% include_cached search-results.html lang=lang %}
+      </div>
+
+      <aside aria-label="Scroll to Top">
+        <button id="back-to-top" type="button" class="btn btn-lg btn-box-shadow">
+          <i class="fas fa-angle-up"></i>
+        </button>
+      </aside>
+    </div>
+
+    <div id="mask" class="d-none position-fixed w-100 h-100 z-1"></div>
+
+    {% if site.pwa.enabled %}
+      {% include_cached notification.html lang=lang %}
+    {% endif %}
+
+    <!-- Embedded scripts -->
+
+    {% for _include in layout.script_includes %}
+      {% assign _include_path = _include | append: '.html' %}
+      {% include {{ _include_path }} %}
+    {% endfor %}
+
+    {% include_cached search-loader.html lang=lang %}
+
+    {% include cookie-banner.html %}
+    <script src="{{ '/assets/js/cookie-consent.js' | relative_url }}"></script>
+  </body>
+</html>

--- a/assets/css/cookie-consent.css
+++ b/assets/css/cookie-consent.css
@@ -1,0 +1,20 @@
+#cookie-banner, #cookie-modal {
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+  right: 1rem;
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 1rem;
+  z-index: 1050;
+  box-shadow: 0 0 10px rgba(0,0,0,0.2);
+}
+#cookie-modal {
+  bottom: auto;
+  top: 50%;
+  transform: translateY(-50%);
+  max-width: 400px;
+  margin: 0 auto;
+}
+#cookie-modal.d-none,
+#cookie-banner.d-none { display: none; }

--- a/assets/js/cookie-consent.js
+++ b/assets/js/cookie-consent.js
@@ -1,0 +1,92 @@
+(function() {
+  const banner = document.getElementById('cookie-banner');
+  const modal = document.getElementById('cookie-modal');
+  const acceptBtn = document.getElementById('cookie-accept');
+  const rejectBtn = document.getElementById('cookie-reject');
+  const customizeBtn = document.getElementById('cookie-customize');
+  const saveBtn = document.getElementById('cookie-save');
+  const settingsLink = document.getElementById('cookie-settings-link');
+
+  const analyticsCheck = document.getElementById('consent-analytics');
+  const marketingCheck = document.getElementById('consent-marketing');
+
+  const storageKey = 'cookie-consent';
+
+  function applyConsent(consent) {
+    if (window.gtag) {
+      gtag('consent', 'update', {
+        ad_storage: consent.marketing ? 'granted' : 'denied',
+        analytics_storage: consent.analytics ? 'granted' : 'denied',
+        ad_user_data: consent.marketing ? 'granted' : 'denied',
+        ad_personalization: consent.marketing ? 'granted' : 'denied'
+      });
+    }
+  }
+
+  function saveConsent(consent) {
+    localStorage.setItem(storageKey, JSON.stringify(consent));
+    applyConsent(consent);
+  }
+
+  function loadConsent() {
+    const stored = localStorage.getItem(storageKey);
+    if (stored) return JSON.parse(stored);
+    return null;
+  }
+
+  function showBanner() { banner.classList.remove('d-none'); }
+  function hideBanner() { banner.classList.add('d-none'); }
+  function showModal() { modal.classList.remove('d-none'); }
+  function hideModal() { modal.classList.add('d-none'); }
+
+  acceptBtn.addEventListener('click', function() {
+    const consent = {analytics: true, marketing: true};
+    saveConsent(consent);
+    hideBanner();
+  });
+
+  rejectBtn.addEventListener('click', function() {
+    const consent = {analytics: false, marketing: false};
+    saveConsent(consent);
+    hideBanner();
+  });
+
+  customizeBtn.addEventListener('click', function() {
+    hideBanner();
+    showModal();
+  });
+
+  saveBtn.addEventListener('click', function() {
+    const consent = {
+      analytics: analyticsCheck.checked,
+      marketing: marketingCheck.checked
+    };
+    saveConsent(consent);
+    hideModal();
+  });
+
+  settingsLink.addEventListener('click', function(e) {
+    e.preventDefault();
+    const consent = loadConsent();
+    analyticsCheck.checked = consent ? consent.analytics : false;
+    marketingCheck.checked = consent ? consent.marketing : false;
+    showModal();
+  });
+
+  document.addEventListener('DOMContentLoaded', function() {
+    const consent = loadConsent();
+    if (consent) {
+      applyConsent(consent);
+    } else {
+      showBanner();
+      if (window.gtag) {
+        gtag('consent', 'default', {
+          ad_storage: 'denied',
+          analytics_storage: 'denied',
+          ad_user_data: 'denied',
+          ad_personalization: 'denied'
+        });
+      }
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- add Google Analytics include with default denied consent
- customize default layout to load cookie consent assets
- add cookie banner markup and footer link
- add stylesheet and JavaScript to manage cookie choices

## Testing
- `bash tools/test.sh`

------
https://chatgpt.com/codex/tasks/task_b_6839fb14e9d883319efc90dab45b2279